### PR TITLE
Add a schema for self-reporting

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -1,0 +1,1 @@
+sentry,https://open.sentry.io/funding/osspledge.json

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,131 @@
+import { z, defineCollection } from "astro:content";
+
+/* Welcome to the schema for OSS Pledge.
+ *
+ * If you are implementing an OSS Pledge report for a member organization, and
+ * need to understand how to format it, you've found the source of truth. If
+ * you have questions or run into limitations, please open an issue:
+ *
+ *    https://github.com/getsentry/osspledge.com/issues/new
+ *
+ */
+
+const monetaryPaymentsObject = z
+  .object({
+    // platforms from https://github.com/github/docs/blob/a9a9dd1f948b6e0257ed5da0a9b94cc1be2aa097/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
+    community_bridge: z.number().nonnegative(),
+    github: z.number().nonnegative(),
+    issuehunt: z.number().nonnegative(),
+    ko_fi: z.number().nonnegative(),
+    liberapay: z.number().nonnegative(),
+    open_collective: z.number().nonnegative(),
+    patreon: z.number().nonnegative(),
+    tidelift: z.number().nonnegative(),
+    polar: z.number().nonnegative(),
+    buy_me_a_coffee: z.number().nonnegative(),
+
+    // foundations from https://github.com/Punderthings/fossfoundation/tree/bcdff88533dcd9bf90e2326db7a4363ac8344207/_foundations
+    almalinux: z.number().nonnegative(),
+    apereo: z.number().nonnegative(),
+    asf: z.number().nonnegative(),
+    benetech: z.number().nonnegative(),
+    biobricks: z.number().nonnegative(),
+    bytecode: z.number().nonnegative(),
+    creativecommons: z.number().nonnegative(),
+    django: z.number().nonnegative(),
+    dotnet: z.number().nonnegative(),
+    drupal: z.number().nonnegative(),
+    eclipse: z.number().nonnegative(),
+    eff: z.number().nonnegative(),
+    ffpc: z.number().nonnegative(),
+    freebsd: z.number().nonnegative(),
+    fsf: z.number().nonnegative(),
+    fsfe: z.number().nonnegative(),
+    fsfse: z.number().nonnegative(),
+    fsharp: z.number().nonnegative(),
+    gentoo: z.number().nonnegative(),
+    gnome: z.number().nonnegative(),
+    haiku: z.number().nonnegative(),
+    haskell: z.number().nonnegative(),
+    idcommons: z.number().nonnegative(),
+    isc: z.number().nonnegative(),
+    joomla: z.number().nonnegative(),
+    kde: z.number().nonnegative(),
+    kuali: z.number().nonnegative(),
+    lf: z.number().nonnegative(),
+    lfcharities: z.number().nonnegative(),
+    linuxkernel: z.number().nonnegative(),
+    llvm: z.number().nonnegative(),
+    mozilla: z.number().nonnegative(),
+    netbsd: z.number().nonnegative(),
+    numfocus: z.number().nonnegative(),
+    oasis: z.number().nonnegative(),
+    ocf: z.number().nonnegative(),
+    oeglobal: z.number().nonnegative(),
+    oisf: z.number().nonnegative(),
+    olpc: z.number().nonnegative(),
+    omsf: z.number().nonnegative(),
+    opencompute: z.number().nonnegative(),
+    openconnectivity: z.number().nonnegative(),
+    openid: z.number().nonnegative(),
+    openjsf: z.number().nonnegative(),
+    openrobotics: z.number().nonnegative(),
+    openstack: z.number().nonnegative(),
+    openstreetmap: z.number().nonnegative(),
+    opentransit: z.number().nonnegative(),
+    osc: z.number().nonnegative(),
+    oset: z.number().nonnegative(),
+    osgeo: z.number().nonnegative(),
+    osi: z.number().nonnegative(),
+    owasp: z.number().nonnegative(),
+    pculture: z.number().nonnegative(),
+    perl: z.number().nonnegative(),
+    plone: z.number().nonnegative(),
+    postgresql: z.number().nonnegative(),
+    python: z.number().nonnegative(),
+    rails: z.number().nonnegative(),
+    raspberrypi: z.number().nonnegative(),
+    raspberrypina: z.number().nonnegative(),
+    rubycentral: z.number().nonnegative(),
+    rust: z.number().nonnegative(),
+    sahana: z.number().nonnegative(),
+    scale: z.number().nonnegative(),
+
+    other: z.number().nonnegative(),
+  })
+  .strict() // no unknown keys allowed
+  .partial() // okay if not all present
+  .refine(
+    // but need at least one - stackoverflow.com/a/73294947
+    (obj) => Object.values(obj).some((v) => v !== undefined),
+    "Monetary payments must include at least one valid entry.",
+  );
+
+const memberProvidedData = z.object({
+  name: z.string(),
+  urlLogoWithBackground: z.string().url(),
+  urlLearnMore: z.string().url(),
+  annualReports: z
+    .object({
+      dateYearEnding: z.string().date(),
+      averageNumberOfDevs: z.number().nonnegative(),
+      monetaryPayments: monetaryPaymentsObject,
+      monetaryValueOfTime: z.number().nonnegative(),
+      monetaryValueOfMaterials: z.number().nonnegative(),
+    })
+    .array()
+    .nonempty(),
+});
+
+export const collections = {
+  members: defineCollection({
+    type: "data",
+    schema: z
+      .object({
+        domain: z.string(),
+        urlSource: z.string().url(),
+        datetimeModified: z.string().datetime(),
+      })
+      .merge(memberProvidedData),
+  }),
+};

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,96 +10,10 @@ import { z, defineCollection } from "astro:content";
  *
  */
 
-const monetaryPaymentsObject = z
-  .object({
-    // platforms from https://github.com/github/docs/blob/a9a9dd1f948b6e0257ed5da0a9b94cc1be2aa097/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
-    community_bridge: z.number().nonnegative(),
-    github: z.number().nonnegative(),
-    issuehunt: z.number().nonnegative(),
-    ko_fi: z.number().nonnegative(),
-    liberapay: z.number().nonnegative(),
-    open_collective: z.number().nonnegative(),
-    patreon: z.number().nonnegative(),
-    tidelift: z.number().nonnegative(),
-    polar: z.number().nonnegative(),
-    buy_me_a_coffee: z.number().nonnegative(),
-
-    // foundations from https://github.com/Punderthings/fossfoundation/tree/bcdff88533dcd9bf90e2326db7a4363ac8344207/_foundations
-    almalinux: z.number().nonnegative(),
-    apereo: z.number().nonnegative(),
-    asf: z.number().nonnegative(),
-    benetech: z.number().nonnegative(),
-    biobricks: z.number().nonnegative(),
-    bytecode: z.number().nonnegative(),
-    creativecommons: z.number().nonnegative(),
-    django: z.number().nonnegative(),
-    dotnet: z.number().nonnegative(),
-    drupal: z.number().nonnegative(),
-    eclipse: z.number().nonnegative(),
-    eff: z.number().nonnegative(),
-    ffpc: z.number().nonnegative(),
-    freebsd: z.number().nonnegative(),
-    fsf: z.number().nonnegative(),
-    fsfe: z.number().nonnegative(),
-    fsfse: z.number().nonnegative(),
-    fsharp: z.number().nonnegative(),
-    gentoo: z.number().nonnegative(),
-    gnome: z.number().nonnegative(),
-    haiku: z.number().nonnegative(),
-    haskell: z.number().nonnegative(),
-    idcommons: z.number().nonnegative(),
-    isc: z.number().nonnegative(),
-    joomla: z.number().nonnegative(),
-    kde: z.number().nonnegative(),
-    kuali: z.number().nonnegative(),
-    lf: z.number().nonnegative(),
-    lfcharities: z.number().nonnegative(),
-    linuxkernel: z.number().nonnegative(),
-    llvm: z.number().nonnegative(),
-    mozilla: z.number().nonnegative(),
-    netbsd: z.number().nonnegative(),
-    numfocus: z.number().nonnegative(),
-    oasis: z.number().nonnegative(),
-    ocf: z.number().nonnegative(),
-    oeglobal: z.number().nonnegative(),
-    oisf: z.number().nonnegative(),
-    olpc: z.number().nonnegative(),
-    omsf: z.number().nonnegative(),
-    opencompute: z.number().nonnegative(),
-    openconnectivity: z.number().nonnegative(),
-    openid: z.number().nonnegative(),
-    openjsf: z.number().nonnegative(),
-    openrobotics: z.number().nonnegative(),
-    openstack: z.number().nonnegative(),
-    openstreetmap: z.number().nonnegative(),
-    opentransit: z.number().nonnegative(),
-    osc: z.number().nonnegative(),
-    oset: z.number().nonnegative(),
-    osgeo: z.number().nonnegative(),
-    osi: z.number().nonnegative(),
-    owasp: z.number().nonnegative(),
-    pculture: z.number().nonnegative(),
-    perl: z.number().nonnegative(),
-    plone: z.number().nonnegative(),
-    postgresql: z.number().nonnegative(),
-    python: z.number().nonnegative(),
-    rails: z.number().nonnegative(),
-    raspberrypi: z.number().nonnegative(),
-    raspberrypina: z.number().nonnegative(),
-    rubycentral: z.number().nonnegative(),
-    rust: z.number().nonnegative(),
-    sahana: z.number().nonnegative(),
-    scale: z.number().nonnegative(),
-
-    other: z.number().nonnegative(),
-  })
-  .strict() // no unknown keys allowed
-  .partial() // okay if not all present
-  .refine(
-    // but need at least one - stackoverflow.com/a/73294947
-    (obj) => Object.values(obj).some((v) => v !== undefined),
-    "Monetary payments must include at least one valid entry.",
-  );
+const monetaryPayment = z.object({
+  amount: z.number().nonnegative(),
+  urlDetails: z.string().url().optional(),
+})
 
 const memberProvidedData = z.object({
   name: z.string(),
@@ -109,7 +23,7 @@ const memberProvidedData = z.object({
     .object({
       dateYearEnding: z.string().date(),
       averageNumberOfDevs: z.number().nonnegative(),
-      monetaryPayments: monetaryPaymentsObject,
+      monetaryPayments: monetaryPayment.array().nonempty(),
       monetaryValueOfTime: z.number().nonnegative(),
       monetaryValueOfMaterials: z.number().nonnegative(),
     })

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -19,6 +19,7 @@ const memberProvidedData = z.object({
   name: z.string(),
   urlLogoWithBackground: z.string().url(),
   urlLearnMore: z.string().url(),
+  description: z.string().optional(),
   annualReports: z
     .object({
       dateYearEnding: z.string().date(),

--- a/src/content/members/sentry.json
+++ b/src/content/members/sentry.json
@@ -9,12 +9,12 @@
     {
       "dateYearEnding": "2024-01-31",
       "averageNumberOfDevs": 10,
-      "monetaryPayments": {
-        "python": 10000,
-        "openjsf": 10000,
-        "rust": 10000
-      },
-      "monetaryValueOfTime": 10000,
+      "monetaryPayments": [
+        {"amount": 435000, "urlDetails": "https://thanks.dev/d/gh/getsentry/dependencies"},
+        {"amount": 50000, "urlDetails": "https://github.com/orgs/getsentry/sponsoring"},
+        {"amount": 15000, "urlDetails": "https://blog.sentry.io/we-just-gave-500-000-dollars-to-open-source-maintainers/"}
+      ],
+      "monetaryValueOfTime": 100000,
       "monetaryValueOfMaterials": 500000
     }
   ]

--- a/src/content/members/sentry.json
+++ b/src/content/members/sentry.json
@@ -1,0 +1,21 @@
+{
+  "domain": "sentry.io",
+  "urlSource": "https://open.sentry.io/osspledge/data.json",
+  "datetimeModified": "2024-07-19T12:24:46Z",
+  "name": "Sentry",
+  "urlLogoWithBackground": "https://fossfunders.com/logos/sentry.svg",
+  "urlLearnMore": "https://open.sentry.io/osspledge/",
+  "annualReports": [
+    {
+      "dateYearEnding": "2024-01-31",
+      "averageNumberOfDevs": 10,
+      "monetaryPayments": {
+        "python": 10000,
+        "openjsf": 10000,
+        "rust": 10000
+      },
+      "monetaryValueOfTime": 10000,
+      "monetaryValueOfMaterials": 500000
+    }
+  ]
+}

--- a/src/content/members/sentry.json
+++ b/src/content/members/sentry.json
@@ -8,7 +8,7 @@
   "annualReports": [
     {
       "dateYearEnding": "2024-01-31",
-      "averageNumberOfDevs": 10,
+      "averageNumberOfDevs": 135,
       "monetaryPayments": [
         {"amount": 435000, "urlDetails": "https://thanks.dev/d/gh/getsentry/dependencies"},
         {"amount": 50000, "urlDetails": "https://github.com/orgs/getsentry/sponsoring"},

--- a/src/content/members/sentry.json
+++ b/src/content/members/sentry.json
@@ -2,12 +2,13 @@
   "domain": "sentry.io",
   "urlSource": "https://open.sentry.io/osspledge/data.json",
   "datetimeModified": "2024-07-19T12:24:46Z",
+  "description": "Sentry has given to Open Source for soooooo many years.",
   "name": "Sentry",
   "urlLogoWithBackground": "https://fossfunders.com/logos/sentry.svg",
   "urlLearnMore": "https://open.sentry.io/osspledge/",
   "annualReports": [
     {
-      "dateYearEnding": "2024-01-31",
+      "dateYearEnding": "2023-01-31",
       "averageNumberOfDevs": 135,
       "monetaryPayments": [
         {"amount": 435000, "urlDetails": "https://thanks.dev/d/gh/getsentry/dependencies"},

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,16 +30,6 @@ const members = await getCollection('members');
         to settle up.
       </p>
 
-      <h2 class="text-app-green mt-8 mb-4 text-3xl font-bold">Who</h2>
-
-      <ul>
-        {members.map(member => (
-          <li>
-            <a href={`/members/${member.id}/`}>{member.data.name}</a>
-          </li>
-        ))}
-      </ul>
-
       <h2 class="text-app-green mt-8 mb-4 text-3xl font-bold">How</h2>
 
       <b>Step 1:</b> Pay Open Source maintainers.<br />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,10 @@
 ---
+import { getCollection } from 'astro:content';
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
 import Button from "../components/Button.astro";
+
+const members = await getCollection('members');
 ---
 
 <Layout title="OSS Pledge">
@@ -26,6 +29,16 @@ import Button from "../components/Button.astro";
         Our companies feast year after year at the Open Source table. It's time
         to settle up.
       </p>
+
+      <h2 class="text-app-green mt-8 mb-4 text-3xl font-bold">Who</h2>
+
+      <ul>
+        {members.map(member => (
+          <li>
+            <a href={`/members/${member.id}/`}>{member.data.name}</a>
+          </li>
+        ))}
+      </ul>
 
       <h2 class="text-app-green mt-8 mb-4 text-3xl font-bold">How</h2>
 

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -29,26 +29,7 @@ const reports = member.data.annualReports;
   
         <b>$3000 / dev</b>
 
-        <h4>Total Contributions</h4>
-        <table>
-          <tr>
-            <th>Item</th>
-            <th>Amount ($)</th>
-          </tr>
-          <tr>
-            <td>payments</td>
-            <td>30000</td>
-          </tr>
-          <tr>
-            <td>value of time</td>
-            <td>{report.monetaryValueOfTime}</td>
-          </tr>
-          <tr>
-            <td>value of materials</td>
-            <td>{report.monetaryValueOfMaterials}</td>
-          </tr>
-        </table>
-        <h4>Payments</h4>
+        <h4>Payments to Independent Maintainers</h4>
         <table>
           <tr>
             <th>Recipient</th>
@@ -69,6 +50,30 @@ const reports = member.data.annualReports;
           <tr>
             <td>$ / dev</td>
             <td>3000</td>
+          </tr>
+        </table>
+
+        <h4>Total Contributions</h4>
+        <table>
+          <tr>
+            <th>Item</th>
+            <th>Amount ($)</th>
+          </tr>
+          <tr>
+            <td>payments to independent maintainers</td>
+            <td>30000</td>
+          </tr>
+          <tr>
+            <td>value of time</td>
+            <td>{report.monetaryValueOfTime}</td>
+          </tr>
+          <tr>
+            <td>value of materials</td>
+            <td>{report.monetaryValueOfMaterials}</td>
+          </tr>
+          <tr>
+            <td></td>
+            <td>540000</td>
           </tr>
         </table>
       </div>)}

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -46,7 +46,7 @@ function getPlatformName(url) {
       {reports.map(report => <div class="annual-report">
         <h3>Year Ending {report.dateYearEnding}</h3>
   
-        <b>$3000 / dev</b>
+        <b>$3700 / dev</b>
 
         <h4>Payments to Independent Maintainers</h4>
         <table>
@@ -60,7 +60,7 @@ function getPlatformName(url) {
           </tr>)}
           <tr>
             <td>total</td>
-            <td class="text-right">30000</td>
+            <td class="text-right">500000</td>
           </tr>
           <tr>
             <td>average number of devs</td>
@@ -68,7 +68,7 @@ function getPlatformName(url) {
           </tr>
           <tr>
             <td>$ / dev</td>
-            <td class="text-right">3000</td>
+            <td class="text-right">3700</td>
           </tr>
         </table>
 
@@ -87,16 +87,16 @@ function getPlatformName(url) {
             <td class="text-right">{report.monetaryValueOfMaterials}</td>
           </tr>
           <tr>
-            <td>subtotal</td>
-            <td class="text-right">510000</td>
+            <td></td>
+            <td class="text-right">600000</td>
           </tr>
           <tr>
             <td>payments to independent maintainers</td>
-            <td class="text-right">30000</td>
+            <td class="text-right">500000</td>
           </tr>
           <tr>
             <td>total</td>
-            <td class="text-right">540000</td>
+            <td class="text-right">1100000</td>
           </tr>
         </table>
       </div>)}

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -41,6 +41,8 @@ function getPlatformName(url) {
 
       <img src={member.data.urlLogoWithBackground}>
 
+      <p>{member.data.description}</p>
+
       <a href={member.data.urlLearnMore}>Learn more ...</a>
 
       {reports.map(report => <div class="annual-report">

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -1,0 +1,90 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from "../../layouts/Layout.astro";
+import Prose from "../../components/Prose.astro";
+
+export async function getStaticPaths() {
+  const members = await getCollection('members');
+  return members.map(member => ({params: {id: member.id}, props: { member }}));
+}
+
+const { member } = Astro.props;
+const reports = member.data.annualReports;
+---
+<Layout title="OSS Pledge">
+  <main class="flex justify-center max-w-xl p-4">
+    <Prose>
+      <h1 class="text-app-green mt-8 mb-4 text-5xl font-bold">OSS Pledge</h1>
+
+      <a href="/">Home</a>
+
+      <h2>{member.data.name}</h2>
+
+      <img src={member.data.urlLogoWithBackground}>
+
+      <a href={member.data.urlLearnMore}>Learn more ...</a>
+
+      {reports.map(report => <div class="annual-report">
+        <h3>Year Ending {report.dateYearEnding}</h3>
+  
+        <b>$3000 / dev</b>
+
+        <h4>Total Contributions</h4>
+        <table>
+          <tr>
+            <th>Item</th>
+            <th>Amount ($)</th>
+          </tr>
+          <tr>
+            <td>payments</td>
+            <td>30000</td>
+          </tr>
+          <tr>
+            <td>value of time</td>
+            <td>{report.monetaryValueOfTime}</td>
+          </tr>
+          <tr>
+            <td>value of materials</td>
+            <td>{report.monetaryValueOfMaterials}</td>
+          </tr>
+        </table>
+        <h4>Payments</h4>
+        <table>
+          <tr>
+            <th>Recipient</th>
+            <th>Amount ($)</th>
+          </tr>
+          {Object.keys(report.monetaryPayments).sort().map(recipient => <tr>
+            <td>{recipient}</td>
+            <td>{report.monetaryPayments[recipient]}</td>
+          </tr>)}
+          <tr>
+            <td></td>
+            <td>30000</td>
+          </tr>
+          <tr>
+            <td>average number of devs</td>
+            <td>{report.averageNumberOfDevs}</td>
+          </tr>
+          <tr>
+            <td>$ / dev</td>
+            <td>3000</td>
+          </tr>
+        </table>
+      </div>)}
+
+    </Prose>
+  </main>
+</Layout>
+
+<style>
+  main {
+    margin: auto;
+    padding: 1rem;
+    width: 800px;
+    max-width: calc(100% - 2rem);
+    color: white;
+    font-size: 20px;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -10,6 +10,25 @@ export async function getStaticPaths() {
 
 const { member } = Astro.props;
 const reports = member.data.annualReports;
+
+function getPlatformName(url) {
+  let host = '';
+  let name = 'Other';
+  try {
+    host = new URL(url).host;
+  } catch (err) {
+    host = '';
+  }
+  switch(host) {
+    case 'github.com':
+      name = 'GitHub Sponsors';
+      break;
+    case 'thanks.dev':
+      name = 'Thanks.dev';
+      break;
+  }
+  return name;
+}
 ---
 <Layout title="OSS Pledge">
   <main class="flex justify-center max-w-xl p-4">
@@ -32,48 +51,52 @@ const reports = member.data.annualReports;
         <h4>Payments to Independent Maintainers</h4>
         <table>
           <tr>
-            <th>Recipient</th>
+            <th>Platform</th>
             <th>Amount ($)</th>
           </tr>
-          {Object.keys(report.monetaryPayments).sort().map(recipient => <tr>
-            <td>{recipient}</td>
-            <td>{report.monetaryPayments[recipient]}</td>
+          {report.monetaryPayments.map(entry => <tr>
+            <td><a href={entry.urlDetails}>{getPlatformName(entry.urlDetails)}</a></td>
+            <td class="text-right">{entry.amount}</td>
           </tr>)}
           <tr>
-            <td></td>
-            <td>30000</td>
+            <td>total</td>
+            <td class="text-right">30000</td>
           </tr>
           <tr>
             <td>average number of devs</td>
-            <td>{report.averageNumberOfDevs}</td>
+            <td class="text-right">{report.averageNumberOfDevs}</td>
           </tr>
           <tr>
             <td>$ / dev</td>
-            <td>3000</td>
+            <td class="text-right">3000</td>
           </tr>
         </table>
 
-        <h4>Total Contributions</h4>
+        <h4>Other Contributions</h4>
         <table>
           <tr>
             <th>Item</th>
-            <th>Amount ($)</th>
-          </tr>
-          <tr>
-            <td>payments to independent maintainers</td>
-            <td>30000</td>
+            <th class="text-right">Amount ($)</th>
           </tr>
           <tr>
             <td>value of time</td>
-            <td>{report.monetaryValueOfTime}</td>
+            <td class="text-right">{report.monetaryValueOfTime}</td>
           </tr>
           <tr>
             <td>value of materials</td>
-            <td>{report.monetaryValueOfMaterials}</td>
+            <td class="text-right">{report.monetaryValueOfMaterials}</td>
           </tr>
           <tr>
-            <td></td>
-            <td>540000</td>
+            <td>subtotal</td>
+            <td class="text-right">510000</td>
+          </tr>
+          <tr>
+            <td>payments to independent maintainers</td>
+            <td class="text-right">30000</td>
+          </tr>
+          <tr>
+            <td>total</td>
+            <td class="text-right">540000</td>
           </tr>
         </table>
       </div>)}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "strictNullChecks": true,
 }


### PR DESCRIPTION
Light-weight self-reporting is a central part of the OSS Pledge. What should the format be? ~Let's define it using [JSON Schema](https://json-schema.org/) for easy validation and interoperability.~ Going with Zod as part of Astro since that's what we've set up in this repo.

([X](https://x.com/chadwhitacre_/status/1805707160049139881) reachout)

### System Design

1. Companies host an `osspledge.json` on their own domain (think `robots.txt`).
2. We have a `members.csv` in this repo containing `slug,url` for members.
3. Joining Pledge is by PR to this repo, adding to `members.csv`
4. We have a GHA automation to update `src/members/{slug}.json` when `members.csv` changes.
5. We have another automation to update `{slug}.json` periodically based on modtime stored therein.