### PR TITLE
Add StackBlitz

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -11,3 +11,4 @@ keygen,https://assets.keygen.sh/reports/osspledge.json
 browserbase,https://www.browserbase.com/osspledge.json
 frontend-masters,https://static.frontendmasters.com/assets/brand/osspledge/osspledge.json
 chieftools,https://chief.app/.well-known/osspledge.json
+stackblitz,https://blog.stackblitz.com/osspledge.json


### PR DESCRIPTION
First of all, congrats on the repercussions of the OSS Pledge initiative. It is great to see all the OSS sustainability discussions that it has sparked.

At [StackBlitz](https://stackblitz.com), we have been backing OSS infrastructure projects (Vite, Vitest, Volar, Wasm) for the past years. We're excited to join the OSS Pledge with you.

We have published a blog post explaining our contributions: [StackBlitz Joins OSS Pledge Post](https://blog.stackblitz.com/posts/stackblitz-joins-osspledge/).

We'll be sharing it after we check all looks good and this PR is merged.

I think later on, maybe we could also discuss if OSS maintainers that are hired as full-time employees by companies to work on external projects could be also accounted (this is my case working in Vite, and also Ari Perkkio working in Vitest). For now, we aren't including us for the pledge, and only detailing StackBlitz contributions to external maintainers.

Thanks again for pushing this initiative forward!

Note: here is a SVG for the [StackBlitz Logo](https://viteconf.org/images/logos/stackblitz.svg), let me know if you need other assets.