### PR TITLE
Remove remaining references to "donation"

### DIFF
--- a/src/members.ts
+++ b/src/members.ts
@@ -52,7 +52,7 @@ export function filterInactiveMembers(members: MemberWithId[]): MemberWithId[] {
 }
 
 /**
- * Puts members into groups based on the dollars per dev donated in their latest
+ * Puts members into groups based on the dollars per dev in their latest
  * annual report, where the groups are set out by `DEV_GROUP_BOUNDS`.
  */
 export function groupMembers(members: MemberWithId[]): MemberWithId[][] {
@@ -94,7 +94,7 @@ export function sortMembersByDevs(members: MemberWithId[]): MemberWithId[] {
 }
 
 /**
- * Sorts members by the dollars per dev donated in their latest annual report.
+ * Sorts members by the dollars per dev in their latest annual report.
  */
 export function sortMembersByDollarsPerDev(members: MemberWithId[]): MemberWithId[] {
   return members.toSorted((m1, m2) => {

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -39,9 +39,9 @@ import Layout from "../layouts/Layout.astro";
             <h3><span class="inline-number">1. </span>Pay $2,000 per full-time equivalent developer on staff</h3>
             to any Open Source maintainers or
             <a href="https://fossfoundation.info/">foundations</a>
-            of your choice, and commit to doing so in future years. The projects you're donating to should meet the
+            of your choice, and commit to doing so in future years. The projects you're paying should meet the
             <a href="https://opensource.org/osd">Open Source Definition</a>.
-            Of course, this includes any existing donations you've made this year. If you need help figuring out which
+            Of course, this includes any existing payments you've made this year. If you need help figuring out which
             projects you depend on, you can use a tool like <a href="https://thanks.dev">thanks.dev</a>.
           </div>
         </div>
@@ -74,7 +74,7 @@ import Layout from "../layouts/Layout.astro";
             <span class="circled">3</span>
           </div>
           <div class="step">
-            <h3><span class="inline-number">3. </span>Create a short JSON file with your company and donation info,</h3>
+            <h3><span class="inline-number">3. </span>Create a short JSON file with your company and payment info,</h3>
             and host it at any URL you wish. Update it at least once per calendar year — we'll fetch it regularly.
 
             <p>


### PR DESCRIPTION
I just had a call with @peerrich and it surfaced that we still have a few lingering references to "donations" as opposed to "payments" to maintainers. We should be consistent about this.