### PR TITLE
Clarify annual report dates

### DIFF
--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -91,7 +91,7 @@ import Layout from "../layouts/Layout.astro";
           </div>
           <div class="step">
             <h3><span class="inline-number">3. </span>Create a short JSON file with your company and payment info,</h3>
-            and host it at any URL you wish. Update it at least once per calendar year — we'll fetch it regularly.
+            and host it at any URL you wish.
 
             <p>
               Want to do things by hand?
@@ -207,8 +207,7 @@ import Layout from "../layouts/Layout.astro";
             <a
               href="https://github.com/opensourcepledge/opensourcepledge.com/blob/main/members.csv"
               >members.csv</a
-            >. The format is <code>company-slug,json-url</code>. Please note that there should be no space in the company
-            slug.
+            >. The format is <code>company-slug,json-url</code>. There should be no spaces in the company slug.
           </div>
         </div>
         <div class="highlight-box">
@@ -244,7 +243,23 @@ import Layout from "../layouts/Layout.astro";
           on your website and marketing materials if you wish. Thank you so much for joining us in contributing to a
           healthy Open Source ecosystem that supports maintainers.
         </p>
+
+        <h2>Future Annual Reports</h2>
+
+        <p
+          >To remain a member, you should publish annual reports every year and add them to your JSON file. We'll fetch
+          this file automatically.</p
+        >
+
+        <p
+          >Future annual reports should end on the same day of the year as your initial annual report. For example, if
+          your first annual report was for the year ending October 1st 2024, your next annual report should contain data
+          for the year ending October 1st 2025. Of course, you can actually publish this report at any time, for example
+          if you've already made all of your donations earlier in the year.</p
+        >
+
         <h2>Questions?</h2>
+
         <p>
           Feel free to
           <a href="https://github.com/opensourcepledge/opensourcepledge.com/issues/new"


### PR DESCRIPTION
We've previously used confusing wording for this, eg by saying that members should publish reports “at least” yearly. This gets confusing because, if members published more frequently than yearly, the reports themselves would not be yearly reports, so we would either be unable to compare them, or would have to somehow pro-rate or merge them.

This new description clarifies that reports are yearly, and must all end on the same day of the year, but can be published at any time, eg earlier in the year.