### PR TITLE
Add total tally

### DIFF
--- a/src/components/TotalTally.astro
+++ b/src/components/TotalTally.astro
@@ -9,7 +9,7 @@ import {
 ---
 
 <div class="total-tally">
-  <p>This past year our members have paid maintainers</p>
+  <p>Our members have paid maintainers</p>
   <h2>{fmtCurrency(await getGrandTotalRaised())}</h2>
 </div>
 

--- a/src/components/TotalTally.astro
+++ b/src/components/TotalTally.astro
@@ -1,0 +1,41 @@
+---
+// © 2024 Vlad-Stefan Harbuz <vlad@vladh.net>
+// SPDX-License-Identifier: Apache-2.0
+
+import LeaderboardMember from "./LeaderboardMember.astro";
+import {
+  getGrandTotalRaised, fmtCurrency,
+} from '../members.ts';
+---
+
+<div class="total-tally">
+  <p>Our members have paid maintainers</p>
+  <h2>{fmtCurrency(await getGrandTotalRaised())}</h2>
+</div>
+
+<style>
+  .total-tally {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin: 2rem 0;
+    padding: 1rem;
+    p {
+      margin: 0;
+    }
+    h2 + p {
+      margin-top: 0.5rem;
+    }
+    h2 {
+      max-width: 100%;
+      margin: 0;
+      font-size: min(3rem, 10vw);
+      text-decoration: underline;
+      text-decoration-thickness: 0.5rem;
+      text-decoration-color: var(--color-primary);
+      text-underline-offset: 0.4rem;
+    }
+  }
+</style>

--- a/src/components/TotalTally.astro
+++ b/src/components/TotalTally.astro
@@ -9,7 +9,7 @@ import {
 ---
 
 <div class="total-tally">
-  <p>Our members have paid maintainers</p>
+  <p>This past year our members have paid maintainers</p>
   <h2>{fmtCurrency(await getGrandTotalRaised())}</h2>
 </div>
 

--- a/src/components/TotalTally.astro
+++ b/src/components/TotalTally.astro
@@ -2,15 +2,15 @@
 // © 2024 Vlad-Stefan Harbuz <vlad@vladh.net>
 // SPDX-License-Identifier: Apache-2.0
 
-import LeaderboardMember from "./LeaderboardMember.astro";
 import {
   getGrandTotalRaised, fmtCurrency,
-} from '../members.ts';
+} from '../memberFormatting.ts';
 ---
 
 <div class="total-tally">
   <p>Our members have paid maintainers</p>
   <h2>{fmtCurrency(await getGrandTotalRaised())}</h2>
+  <p>over the last year.</p>
 </div>
 
 <style>

--- a/src/memberFormatting.ts
+++ b/src/memberFormatting.ts
@@ -21,9 +21,22 @@ export async function getGrandTotalRaised() {
   const members = filterInactiveMembers(await getMembers());
   let grandTotal = 0;
   members.forEach((member) => {
-    member.data.annualReports.forEach((report) => {
-      grandTotal += report.payments;
+    const sortedAnnualReports = member.data.annualReports.sort((a, b) => {
+      if (a.dateYearEnding > b.dateYearEnding) {
+        return -1;
+      } else if (a.dateYearEnding < b.dateYearEnding) {
+        return 1;
+      } else {
+        return 0;
+      }
     });
+    const report = sortedAnnualReports[0];
+    const reportDate = Date.parse(report.dateYearEnding);
+    const currentYear = (new Date()).getFullYear();
+    const oneYearAgo = (new Date()).setFullYear(currentYear - 1);
+    if (reportDate > oneYearAgo) {
+      grandTotal += report.payments;
+    }
   });
   return grandTotal;
 }

--- a/src/memberFormatting.ts
+++ b/src/memberFormatting.ts
@@ -17,6 +17,17 @@ export function getDollarsPerDev(report: MemberReport) {
   return report.usdAmountPaid / report.averageNumberOfDevs;
 }
 
+export async function getGrandTotalRaised() {
+  const members = filterInactiveMembers(await getMembers());
+  let grandTotal = 0;
+  members.forEach((member) => {
+    member.data.annualReports.forEach((report) => {
+      grandTotal += report.payments;
+    });
+  });
+  return grandTotal;
+}
+
 export function fmtCurrency(num: number) {
   return '$' + num.toLocaleString(undefined, {
     minimumFractionDigits: 0,

--- a/src/memberFormatting.ts
+++ b/src/memberFormatting.ts
@@ -21,9 +21,7 @@ export async function getGrandTotalRaised() {
   const members = filterInactiveMembers(await getMembers());
   let grandTotal = 0;
   members.forEach((member) => {
-    member.data.annualReports.forEach((report) => {
-      grandTotal += report.payments;
-    });
+    grandTotal += member.data.annualReports[0].usdAmountPaid;
   });
   return grandTotal;
 }

--- a/src/memberFormatting.ts
+++ b/src/memberFormatting.ts
@@ -21,22 +21,9 @@ export async function getGrandTotalRaised() {
   const members = filterInactiveMembers(await getMembers());
   let grandTotal = 0;
   members.forEach((member) => {
-    const sortedAnnualReports = member.data.annualReports.sort((a, b) => {
-      if (a.dateYearEnding > b.dateYearEnding) {
-        return -1;
-      } else if (a.dateYearEnding < b.dateYearEnding) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
-    const report = sortedAnnualReports[0];
-    const reportDate = Date.parse(report.dateYearEnding);
-    const currentYear = (new Date()).getFullYear();
-    const oneYearAgo = (new Date()).setFullYear(currentYear - 1);
-    if (reportDate > oneYearAgo) {
+    member.data.annualReports.forEach((report) => {
       grandTotal += report.payments;
-    }
+    });
   });
   return grandTotal;
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,9 +28,7 @@ const members = filterInactiveMembers(await getMembers());
     <Blob kind="grad-dots-03" top="10%" left="-15rem"></Blob>
 
     <main id="main-content">
-      <section>
-        <h1>About the Pledge</h1>
-      </section>
+      <h1>About the Pledge</h1>
 
       <TableOfContents filepath={Astro.self.moduleId || ""} />
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -231,6 +231,15 @@ const members = filterInactiveMembers(await getMembers());
         >
       </section>
 
+      <section id="how-is-the-grand-total-amount-paid-by-members-to-maintainers-calculated">
+        <h2>How is the grand total amount paid by members to maintainers calculated?</h2>
+
+        <p
+          >The grand total is calculated by adding up all of the payments made by our members across all of their annual
+          reports. Note that some of our members' payments may precede their joining the Pledge.</p
+        >
+      </section>
+
       <section id="who-maintains-the-open-source-pledge">
         <h2>Who maintains Open Source Pledge?</h2>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,9 @@ const members = filterInactiveMembers(await getMembers());
     <Blob kind="grad-dots-03" top="10%" left="-15rem"></Blob>
 
     <main id="main-content">
-      <h1>About the Pledge</h1>
+      <section>
+        <h1>About the Pledge</h1>
+      </section>
 
       <TableOfContents filepath={Astro.self.moduleId || ""} />
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -231,15 +231,6 @@ const members = filterInactiveMembers(await getMembers());
         >
       </section>
 
-      <section id="how-is-the-grand-total-amount-paid-by-members-to-maintainers-calculated">
-        <h2>How is the grand total amount paid by members to maintainers calculated?</h2>
-
-        <p
-          >The grand total is calculated by adding up all of the payments made by our members across all of their annual
-          reports. Note that some of our members' payments may precede their joining the Pledge.</p
-        >
-      </section>
-
       <section id="who-maintains-the-open-source-pledge">
         <h2>Who maintains Open Source Pledge?</h2>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import Layout from "../layouts/Layout.astro";
 import MemberLogoBoard from "../components/MemberLogoBoard.astro";
 import PressItemList from "../components/PressItemList.astro";
 import TextButton from "../components/TextButton.astro";
+import TotalTally from "../components/TotalTally.astro";
 ---
 
 <Layout>
@@ -56,6 +57,10 @@ import TextButton from "../components/TextButton.astro";
           <h3><div><span class="circled">2</span></div><span>Self-report annually</span></h3>
           <p>Each year, publish a blog post outlining your payments to maintainers.</p>
         </div>
+      </section>
+
+      <section>
+        <TotalTally />
       </section>
 
       <section>

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -24,10 +24,10 @@ import TotalTally from "../../components/TotalTally.astro";
     <main id="main-content">
       <section>
         <div class="text-center">
-          <h1>Member Companies</h1>
+          <h1>Member<br>Companies</h1>
         </div>
         <TotalTally />
-        <Leaderboard grouped={false} />
+        <Leaderboard grouped={false}></Leaderboard>
       </section>
 
       <section class="flex-center bottom-cta">

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -7,6 +7,7 @@ import Blob from "../../components/Blob.astro";
 import Button from "../../components/Button.astro";
 import Layout from "../../layouts/Layout.astro";
 import Leaderboard from "../../components/Leaderboard.astro";
+import TotalTally from "../../components/TotalTally.astro";
 ---
 
 <Layout title="Members">
@@ -23,9 +24,10 @@ import Leaderboard from "../../components/Leaderboard.astro";
     <main id="main-content">
       <section>
         <div class="text-center">
-          <h1>Member<br>Companies</h1>
+          <h1>Member Companies</h1>
         </div>
-        <Leaderboard grouped={false}></Leaderboard>
+        <TotalTally />
+        <Leaderboard grouped={false} />
       </section>
 
       <section class="flex-center bottom-cta">


### PR DESCRIPTION
Closes #186.

Opening this PR as a place to discuss ideas for implementation details.

Potential issues with this:

* Wordsmithing would be nice.
* We probably want a bit more design work here.
* I think the current phrasing is clear, but maybe it would be worth adding a footnote saying that this is the total of all annual reports of all members we're tracking, including donations made before the Pledge existed.

![2024-10-08-16-23-22](https://github.com/user-attachments/assets/70439f8a-e017-4858-9bed-1d5550b511f1)
