### PR TITLE
Add report archival

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,48 @@ access, contact @selviano.
 
 [member-logos]: https://drive.google.com/drive/folders/1HxYaaY1wy1hZT6O0ZY58s7Y8N4aV0fcn
 
+## Archiving Member Reports
+
+We archive member reports so that, in case they become inaccessible, we can (1) refer to the reports, and (2) have a
+fallback way to display the reports to visitors.
+
+Currently, these reports must be archived manually.
+
+Before archiving reports, make sure you install [`monolith`][monolith] from your package manager. `monolith` is used so
+that we can compactly archive a report into a single file.
+
+[monolith]: https://github.com/Y2Z/monolith
+
+To archive all reports, run this from the repository root:
+
+```
+$ ./src/memberData/bin/archiveMembers.ts
+```
+
+This will archive reports using the following directory structure:
+
+```
+archives/
+└── reports
+    └── sentry
+        ├── 2022
+        │   ├── 2024-11-08T18:11:29.792Z.html
+        │   └── latest.html -> 2024-11-08T18:11:29.792Z.html
+        ├── 2023
+        │   ├── 2024-11-08T18:11:27.057Z.html
+        │   └── latest.html -> 2024-11-08T18:11:27.057Z.html
+        └── 2024
+            ├── 2024-11-08T18:11:24.601Z.html
+            └── latest.html -> 2024-11-08T18:11:24.601Z.html
+```
+
+When a report is archived, the `latest.html` symlink is updated to point to the latest archived HTML file.
+
+Archives are not currently automatically provided to users eg in case the original URL is inaccessible.
+
+If you want to browse the archives locally, it's best to `cd archives`, `python -m http.server`, then visit
+`localhost:8000`. This avoids issues with `file://` URLs.
+
 ## Authorship Information
 
 We maintain copyright headers at the top of every file to establish authorship. Once you make substantive changes to any

--- a/src/memberData/bin/archiveMembers.ts
+++ b/src/memberData/bin/archiveMembers.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S npx tsx
+
+// © 2024 Vlad-Stefan Harbuz <vlad@vlad.website>
+// SPDX-License-Identifier: Apache-2.0
+
+// Must be run in repository root.
+
+import fs from "fs";
+import { execSync } from "child_process";
+import memberRoles from "../../memberRoles.json";
+import dayjs from 'dayjs';
+
+
+function main() {
+  const memberSlugs = Object.keys(memberRoles);
+
+  for (const slug of memberSlugs) {
+    const localPath = `./src/content/members/${slug}.json`;
+
+    let member = undefined;
+    try {
+      member = JSON.parse(fs.readFileSync(localPath).toString());
+    } catch (e) {
+      console.error(`ERROR: could not load member data at ${localPath}`);
+      process.exit(1);
+    }
+
+    for (const report of member.annualReports) {
+      const archiveDir = `./archives/reports/${slug}/${report.year}/`;
+      const archiveFilename = `${dayjs().toISOString()}.html`;
+      const archivePath = `${archiveDir}${archiveFilename}`;
+      const latestArchivePath = `${archiveDir}latest.html`;
+      fs.mkdirSync(archiveDir, { recursive: true });
+
+      const command = `monolith '${report.url}' -o '${archivePath}'`;
+      try {
+        console.log('Archiving...');
+        console.log(`\tRemote URL: ${report.url}`);
+        console.log(`\tLocal path: ${archivePath}`);
+        console.log(`\tInvocation: ${command}`);
+        execSync(command, { stdio: 'pipe' });
+        if (!fs.existsSync(archivePath)) {
+          throw new Error(`Expected file to exist, but it did not, so archival failed: ${archivePath}`);
+        }
+        const lstat = fs.lstatSync(latestArchivePath, { throwIfNoEntry: false });
+        if (lstat) {
+          fs.unlinkSync(latestArchivePath);
+        }
+        console.log(`Creating symlink: ${latestArchivePath} -> ${archiveFilename}`);
+        fs.symlinkSync(archiveFilename, latestArchivePath);
+        console.log('');
+      } catch (error: any) {
+        console.error('ERROR: Could not archive report.');
+        console.error('');
+        console.error('The most common cause is not having `monolith` installed.');
+        console.error('You should install it using your package manager.');
+        console.error('Read more here: https://github.com/Y2Z/monolith');
+        console.error('');
+        console.error('Error information:');
+        console.error(`\tRemote URL: ${report.url}`);
+        console.error(`\tLocal path: ${archivePath}`);
+        console.error(`\tInvocation: ${command}`);
+        console.error(`\tError code: ${error.status}`);
+        console.error(`\tError message: ${error.message.replace('\n', '\n\t\t').trim()}`);
+        console.error('');
+        console.error('Stopping without attempting to archive further reports.');
+        process.exit(1);
+      }
+    }
+  }
+}
+
+
+main()

--- a/src/memberData/bin/checkMembers.ts
+++ b/src/memberData/bin/checkMembers.ts
@@ -3,6 +3,8 @@
 // © 2024 Vlad-Stefan Harbuz <vlad@vlad.website>
 // SPDX-License-Identifier: Apache-2.0
 
+// Must be run in repository root.
+
 import fs from "fs";
 import { Octokit } from "@octokit/rest";
 
@@ -31,24 +33,24 @@ async function main() {
     const localPath = `./src/content/members/${slug}.json`;
     console.log(`Checking member ${slug} at ${localPath}`);
 
-    let memberData = undefined;
+    let member = undefined;
     try {
-      memberData = JSON.parse(fs.readFileSync(localPath).toString());
+      member = JSON.parse(fs.readFileSync(localPath).toString());
     } catch (e) {
       console.error(`ERROR: could not load member data at ${localPath}`);
       process.exit(1);
     }
 
-    if (isReportOverdue(memberData)) {
-      await makeIssueIfNotExists(octokit, MemberException.ReportOverdue, memberData);
-    } else if (isReportDueSoon(memberData)) {
-      await makeIssueIfNotExists(octokit, MemberException.ReportDueSoon, memberData);
+    if (isReportOverdue(member)) {
+      await makeIssueIfNotExists(octokit, MemberException.ReportOverdue, member);
+    } else if (isReportDueSoon(member)) {
+      await makeIssueIfNotExists(octokit, MemberException.ReportDueSoon, member);
     }
-    if (await isMemberUrlNotRetrievable(memberData)) {
-      await makeIssueIfNotExists(octokit, MemberException.MemberUrlNotRetrievable, memberData);
+    if (await isMemberUrlNotRetrievable(member)) {
+      await makeIssueIfNotExists(octokit, MemberException.MemberUrlNotRetrievable, member);
     }
-    if (await isReportUrlNotRetrievable(memberData)) {
-      await makeIssueIfNotExists(octokit, MemberException.ReportUrlNotRetrievable, memberData);
+    if (await isReportUrlNotRetrievable(member)) {
+      await makeIssueIfNotExists(octokit, MemberException.ReportUrlNotRetrievable, member);
     }
   }
 }


### PR DESCRIPTION
This addresses but does not close #245.

First of all, here's a summary about how it works, from `CONTRIBUTING.md`:

---

We archive member reports so that, in case they become inaccessible, we can (1) refer to the reports, and (2) have a
fallback way to display the reports to visitors.

Currently, these reports must be archived manually.

Before archiving reports, make sure you install [`monolith`][monolith] from your package manager. `monolith` is used so
that we can compactly archive a report into a single file.

[monolith]: https://github.com/Y2Z/monolith

To archive all reports, run this from the repository root:

```
$ ./src/memberData/bin/archiveMembers.ts
```

This will archive reports using the following directory structure:

```
archives/
└── reports
    └── sentry
        ├── 2022
        │   ├── 2024-11-08T18:11:29.792Z.html
        │   └── latest.html -> 2024-11-08T18:11:29.792Z.html
        ├── 2023
        │   ├── 2024-11-08T18:11:27.057Z.html
        │   └── latest.html -> 2024-11-08T18:11:27.057Z.html
        └── 2024
            ├── 2024-11-08T18:11:24.601Z.html
            └── latest.html -> 2024-11-08T18:11:24.601Z.html
```

When a report is archived, the `latest.html` symlink is updated to point to the latest archived HTML file.

Archives are not currently automatically provided to users eg in case the original URL is inaccessible.

---

The archiving itself works, but we have two issues.

First of all, there are three members whose reports mysteriously show an error page when viewed as a local file: GitButler, Keygen and Speakeasy. This seems to have something to do with the Javascript on those pages.

Secondly, I did not add the archived `.html` files because some of them are _huge_, so we totalled at 274MB for a single round of archiving:

```
$ du -shc archives/reports/* | sort -h
...
11M	archives/reports/keygen
11M	archives/reports/vlt
16M	archives/reports/chieftools
18M	archives/reports/gitbutler
18M	archives/reports/sentry
38M	archives/reports/rector
93M	archives/reports/prefect
274M	total
```

I looked into this a bit, and it seems that Prefect's website includes many alternate links for the same images, and served PNGs mysteriously cause 10x as much network traffic as the actual PNG file.

This is all to say, let's review/merge this for now and figure out the details of how to run it later. :)