### PR TITLE
Add latest blog post as banner

### DIFF
--- a/src/components/LatestBlogPostBanner.astro
+++ b/src/components/LatestBlogPostBanner.astro
@@ -1,0 +1,77 @@
+---
+// © 2025 Functional Software, Inc. dba Sentry
+// SPDX-License-Identifier: Apache-2.0
+
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);
+
+import type { SanityDocument } from "@sanity/client";
+import { sanityClient } from "sanity:client";
+
+const ARTICLES_QUERY = `*[_type == "article"]|order(publishDateTime desc){
+  _id,
+  title,
+  slug,
+  publishDateTime,
+  author->{name, slug, avatar}
+}`;
+
+const articles = (await sanityClient.fetch<SanityDocument[]>(ARTICLES_QUERY))
+  .filter((a) => dayjs(a.publishDateTime).isBefore(dayjs().utc()));
+
+const article = articles[0];
+---
+
+{ article && (
+<div class="latest-blog-post-banner">
+  <div class="container">
+    <a href=`/blog/${article.slug.current}`>
+      <strong class="latest-long">Latest post</strong>
+      <strong class="latest-short">Latest:&#32;</strong>
+      <span class="sep"></span>
+      <span>{ article.title }</span>
+    </a>
+  </div>
+</div>
+) }
+
+<style>
+  .latest-blog-post-banner {
+    padding: 0.2rem 0;
+    background-color: var(--color-light-bg);
+    a {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      color: var(--color-primary);
+      text-decoration: none;
+      &:hover {
+        color: var(--color-secondary);
+        .sep {
+          border-color: var(--color-secondary);
+        }
+      }
+      @media (max-width: 800px) {
+        display: block;
+        text-align: center;
+        .latest-long {
+          display: none;
+        }
+        .latest-short {
+          display: inline;
+        }
+        .sep {
+          display: none;
+        }
+      }
+    }
+    .latest-short {
+      display: none;
+    }
+    .sep {
+      border-right: 1px solid var(--color-primary);
+      height: 1rem;
+    }
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,8 @@ const {
 } = Astro.props;
 
 import '../styles/common.css';
+
+import LatestBlogPostBanner from "../components/LatestBlogPostBanner.astro";
 ---
 
 <!doctype html>
@@ -63,6 +65,7 @@ import '../styles/common.css';
   </head>
   <body>
     <a class="skiplink" href="#main-content">Skip to main content</a>
+    <LatestBlogPostBanner></LatestBlogPostBanner>
     { !navless && (
       <nav class="container">
         <a href="/">

--- a/src/memberData/bin/getGrandTotalRaised.ts
+++ b/src/memberData/bin/getGrandTotalRaised.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npx tsx
 
-// © 2024 Functional Software, Inc. dba Sentry
+// © 2025 Functional Software, Inc. dba Sentry
 // SPDX-License-Identifier: Apache-2.0
 
 // Must be run in repository root.

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -426,6 +426,7 @@ section {
 nav {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   margin-top: 2rem;
   margin-bottom: 2rem;
   @media (max-width: 800px) {
@@ -433,20 +434,20 @@ nav {
     gap: 1rem;
   }
   a {
-    flex: 1 0;
     text-decoration: none;
     img {
       max-height: 3.5rem;
     }
   }
   ul {
-    flex: 0 1;
     list-style: none;
-    margin: 0 -1rem;
     padding: 0;
     display: flex;
-    li {
-      margin: 0 1rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    column-gap: 2rem;
+    @media (max-width: 800px) {
+      justify-content: center;
     }
   }
 }


### PR DESCRIPTION
This adds the latest blog post to every page. I initially only added the banner for the homepage, but I thought it looked unpleasant when clicking to another page, because the bar disappears which looks jarring. Happy to try other designs though.

## Desktop

![Screen Shot 2025-02-24 at 16 36 17](https://github.com/user-attachments/assets/e6374bc5-1be4-4132-99fc-13da22c2d93c)

## Tablet

![Screen Shot 2025-02-24 at 16 36 21](https://github.com/user-attachments/assets/9da16e4e-f2b6-4e70-bebe-639eb75ab058)

## Mobile

![Screen Shot 2025-02-24 at 16 36 27](https://github.com/user-attachments/assets/a1716ee5-076b-4e69-b8f5-20acec590095)