### PR TITLE
Shift messaging towards FOMO

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,7 +91,7 @@ import TotalTally from "../components/TotalTally.astro";
       <section class="flex-center bottom-cta">
         <div>
           <div class="text-center">
-            <h2>Do the right thing, support Open Source</h2>
+            <h2>Want in?</h2>
           </div>
 
           <div class="text-center">


### PR DESCRIPTION
Follow-up to ... wherever it was that we changed from "Pay your share" to what we have now.

# Before

<img width="946" height="398" alt="image" src="https://github.com/user-attachments/assets/737dc91a-4ab7-4367-84ee-d0b7e94e2b3d" />

# After

<img width="823" height="334" alt="image" src="https://github.com/user-attachments/assets/905d3563-85a0-4760-b750-bf8fda59b517" />
