### PR TITLE
Add 2025 report for Keygen

### DIFF
--- a/data/members/keygen.json
+++ b/data/members/keygen.json
@@ -35,6 +35,13 @@
       "reportDate": "2024-09-09",
       "averageNumberOfDevs": 1,
       "usdAmountPaid": 5428
+    },
+    {
+      "url": "https://keygen.sh/blog/keygen-continues-osspledge/",
+      "year": "2025",
+      "reportDate": "2025-12-30",
+      "averageNumberOfDevs": 2,
+      "usdAmountPaid": 9541
     }
   ]
 }


### PR DESCRIPTION
Closes #464. Report: https://keygen.sh/blog/keygen-continues-osspledge/