### PR TITLE
Add Sanity 2025 annual report

### DIFF
--- a/data/members/sanity.json
+++ b/data/members/sanity.json
@@ -16,6 +16,13 @@
       "reportDate": "2024-11-12",
       "averageNumberOfDevs": 56,
       "usdAmountPaid": 112000
+    },
+    {
+      "url": "https://www.sanity.io/blog/open-source-pledge-2025",
+      "year": "2025",
+      "reportDate": "2025-01-08",
+      "averageNumberOfDevs": 73,
+      "usdAmountPaid": 146000
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adding Sanity's 2025 Open Source Pledge annual report.

**2025 Report Details:**
- **Developers:** 73 (up from 56 in 2024)
- **Amount contributed:** $146,000
- **Blog post:** https://www.sanity.io/blog/open-source-pledge-2025

This represents a 30% increase in both developer count and contribution amount from the 2024 report.

## Changes

- Updated `data/members/sanity.json` to add the 2025 annual report entry